### PR TITLE
Correct mapping for cfdocs

### DIFF
--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -1,6 +1,6 @@
 component {
 
-	this.cfmapping = "cfscriptme-command";
+	this.cfmapping = "cfdocs";
 
 
 	function configure() {


### PR DESCRIPTION
Switch mapping from cfscriptme-command -> cfdocs.